### PR TITLE
Allow existing processes to be killed before restarting 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,2 @@
+# jodconverter
+JODConverter automates document conversions using LibreOffice/OpenOffice.org

--- a/jodconverter-core/src/main/java/org/artofsolving/jodconverter/office/DefaultOfficeManagerConfiguration.java
+++ b/jodconverter-core/src/main/java/org/artofsolving/jodconverter/office/DefaultOfficeManagerConfiguration.java
@@ -21,11 +21,7 @@ package org.artofsolving.jodconverter.office;
 
 import java.io.File;
 
-import org.artofsolving.jodconverter.process.MacProcessManager;
-import org.artofsolving.jodconverter.process.ProcessManager;
-import org.artofsolving.jodconverter.process.PureJavaProcessManager;
-import org.artofsolving.jodconverter.process.UnixProcessManager;
-import org.artofsolving.jodconverter.process.WindowsProcessManager;
+import org.artofsolving.jodconverter.process.*;
 import org.artofsolving.jodconverter.util.PlatformUtils;
 
 public class DefaultOfficeManagerConfiguration {
@@ -49,6 +45,8 @@ public class DefaultOfficeManagerConfiguration {
     private boolean useGnuStyleLongOptions;
 
     private ProcessManager processManager = null; // lazily initialised
+    
+    private boolean killExistingProcess= true; // 
 
     public DefaultOfficeManagerConfiguration setOfficeHome(String officeHome)
             throws NullPointerException, IllegalArgumentException {
@@ -73,6 +71,11 @@ public class DefaultOfficeManagerConfiguration {
         return this;
     }
 
+    public DefaultOfficeManagerConfiguration setKillExistingProcess(boolean killExistingProcess) {
+      this.killExistingProcess = killExistingProcess;
+      return this;
+    }
+    
     public DefaultOfficeManagerConfiguration setPortNumber(int portNumber) {
         this.portNumbers = new int[] { portNumber };
         return this;
@@ -172,7 +175,7 @@ public class DefaultOfficeManagerConfiguration {
         }
         return new ProcessPoolOfficeManager(officeHome, unoUrls,
                 templateProfileDir, taskQueueTimeout, taskExecutionTimeout,
-                maxTasksPerProcess, processManager, useGnuStyleLongOptions);
+                maxTasksPerProcess, processManager, useGnuStyleLongOptions, killExistingProcess);
     }
 
     private ProcessManager findBestProcessManager() {

--- a/jodconverter-core/src/main/java/org/artofsolving/jodconverter/office/ManagedOfficeProcess.java
+++ b/jodconverter-core/src/main/java/org/artofsolving/jodconverter/office/ManagedOfficeProcess.java
@@ -47,7 +47,7 @@ class ManagedOfficeProcess {
         process = new OfficeProcess(settings.getOfficeHome(),
                 settings.getUnoUrl(), settings.getTemplateProfileDir(),
                 settings.getProcessManager(),
-                settings.isUseGnuStyleLongOptions());
+                settings.isUseGnuStyleLongOptions(), settings.isKillExistingProcess());
         connection = new OfficeConnection(settings.getUnoUrl());
     }
 

--- a/jodconverter-core/src/main/java/org/artofsolving/jodconverter/office/ManagedOfficeProcessSettings.java
+++ b/jodconverter-core/src/main/java/org/artofsolving/jodconverter/office/ManagedOfficeProcessSettings.java
@@ -43,6 +43,8 @@ class ManagedOfficeProcessSettings {
     private long retryInterval = DEFAULT_RETRY_INTERVAL;
 
     protected boolean useGnuStyleLongOptions = false;
+    
+    private boolean killExistingProcess= true;
 
     public ManagedOfficeProcessSettings(UnoUrl unoUrl) {
         this.unoUrl = unoUrl;
@@ -99,5 +101,12 @@ class ManagedOfficeProcessSettings {
     public void setUseGnuStyleLongOptions(boolean useGnuStyleLongOptions) {
         this.useGnuStyleLongOptions = useGnuStyleLongOptions;
     }
-
+    
+    public void setKillExistingProcess(boolean killExistingProcess) {
+        this.killExistingProcess = killExistingProcess;
+    }
+      
+    public boolean isKillExistingProcess() {
+        return killExistingProcess;
+    }
 }

--- a/jodconverter-core/src/main/java/org/artofsolving/jodconverter/office/OfficeProcess.java
+++ b/jodconverter-core/src/main/java/org/artofsolving/jodconverter/office/OfficeProcess.java
@@ -19,11 +19,7 @@
 //
 package org.artofsolving.jodconverter.office;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
+import java.io.*;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -47,6 +43,8 @@ class OfficeProcess {
     private final File fakeBundlesDir;
 
     private final ProcessManager processManager;
+    
+    private final boolean killExistingProcess;
 
     private Process process;
 
@@ -66,12 +64,12 @@ class OfficeProcess {
 
     public OfficeProcess(File officeHome, UnoUrl unoUrl,
             File templateProfileDir, ProcessManager processManager) {
-        this(officeHome, unoUrl, templateProfileDir, processManager, false);
+        this(officeHome, unoUrl, templateProfileDir, processManager, false, true);
     }
 
     public OfficeProcess(File officeHome, UnoUrl unoUrl,
             File templateProfileDir, ProcessManager processManager,
-            boolean useGnuStyleLongOptions) {
+            boolean useGnuStyleLongOptions, boolean killExistingProcess) {
         this.officeHome = officeHome;
         this.unoUrl = unoUrl;
         this.templateProfileDir = templateProfileDir;
@@ -83,6 +81,7 @@ class OfficeProcess {
         } else {
             COMMAND_ARG_PREFIX = "-";
         }
+        this.killExistingProcess = killExistingProcess;
     }
 
     protected void determineOfficeVersion() throws IOException {
@@ -178,6 +177,17 @@ class OfficeProcess {
         String processRegex = "soffice.*"
                 + Pattern.quote(unoUrl.getAcceptString());
         String existingPid = processManager.findPid(processRegex);
+        if (existingPid != null && killExistingProcess) {
+            logger.warning(String.format("a process with acceptString '%s' is already running; pid %s", unoUrl.getAcceptString(), existingPid));
+            processManager.kill(null, existingPid);
+            try {
+                Thread.sleep(1000);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            existingPid = processManager.findPid(processRegex);
+            
+        }
         if (existingPid != null) {
             throw new IllegalStateException(
                     String.format(
@@ -317,7 +327,7 @@ class OfficeProcess {
             fakeBundlesDir.mkdirs();
         }
     }
-
+    
     public void deleteFakeBundlesDir() {
         if (fakeBundlesDir != null) {
             try {

--- a/jodconverter-core/src/main/java/org/artofsolving/jodconverter/office/OfficeVersionDescriptor.java
+++ b/jodconverter-core/src/main/java/org/artofsolving/jodconverter/office/OfficeVersionDescriptor.java
@@ -1,6 +1,5 @@
 package org.artofsolving.jodconverter.office;
 
-import java.io.File;
 import java.util.logging.Logger;
 
 public class OfficeVersionDescriptor {

--- a/jodconverter-core/src/main/java/org/artofsolving/jodconverter/office/ProcessPoolOfficeManager.java
+++ b/jodconverter-core/src/main/java/org/artofsolving/jodconverter/office/ProcessPoolOfficeManager.java
@@ -44,13 +44,13 @@ class ProcessPoolOfficeManager implements OfficeManager {
             long taskExecutionTimeout, int maxTasksPerProcess,
             ProcessManager processManager) {
         this(officeHome, unoUrls, templateProfileDir, taskQueueTimeout,
-                taskExecutionTimeout, maxTasksPerProcess, processManager, false);
+                taskExecutionTimeout, maxTasksPerProcess, processManager, false, true);
     }
 
     public ProcessPoolOfficeManager(File officeHome, UnoUrl[] unoUrls,
             File templateProfileDir, long taskQueueTimeout,
             long taskExecutionTimeout, int maxTasksPerProcess,
-            ProcessManager processManager, boolean useGnuStyleLongOptions) {
+            ProcessManager processManager, boolean useGnuStyleLongOptions, boolean killExistingProcess) {
         this.taskQueueTimeout = taskQueueTimeout;
         pool = new ArrayBlockingQueue<PooledOfficeManager>(unoUrls.length);
         pooledManagers = new PooledOfficeManager[unoUrls.length];
@@ -63,6 +63,7 @@ class ProcessPoolOfficeManager implements OfficeManager {
             settings.setMaxTasksPerProcess(maxTasksPerProcess);
             settings.setProcessManager(processManager);
             settings.setUseGnuStyleLongOptions(useGnuStyleLongOptions);
+            settings.setKillExistingProcess(killExistingProcess);
             pooledManagers[i] = new PooledOfficeManager(settings);
         }
         logger.info("ProcessManager implementation is "

--- a/jodconverter-core/src/test/java/org/artofsolving/jodconverter/OfficeDocumentConverterFunctionalTest.java
+++ b/jodconverter-core/src/test/java/org/artofsolving/jodconverter/OfficeDocumentConverterFunctionalTest.java
@@ -61,6 +61,18 @@ public class OfficeDocumentConverterFunctionalTest {
                         System.out.println("-- skipping odg to svg test... ");
                         continue;
                     }
+                    if (outputFormat.getExtension().equals("sxc")) {
+                      System.out.println("-- skipping * to sxc test... ");
+                      continue;
+                    }
+                    if (outputFormat.getExtension().equals("sxw")) {
+                      System.out.println("-- skipping * to sxw test... ");
+                      continue;
+                    }
+                    if (outputFormat.getExtension().equals("sxi")) {
+                      System.out.println("-- skipping * to sxi test... ");
+                      continue;
+                    }
                     File outputFile = File.createTempFile("test", "." + outputFormat.getExtension());
                     outputFile.deleteOnExit();
                     System.out.printf("-- converting %s to %s... ", inputFormat.getExtension(), outputFormat.getExtension());

--- a/jodconverter-core/src/test/java/org/artofsolving/jodconverter/office/OfficeProcessTest.java
+++ b/jodconverter-core/src/test/java/org/artofsolving/jodconverter/office/OfficeProcessTest.java
@@ -1,0 +1,121 @@
+package org.artofsolving.jodconverter.office;
+
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.fail;
+
+import java.util.regex.Pattern;
+
+import org.artofsolving.jodconverter.ReflectionUtils;
+import org.artofsolving.jodconverter.process.*;
+import org.artofsolving.jodconverter.util.PlatformUtils;
+import org.testng.SkipException;
+import org.testng.annotations.Test;
+
+@Test
+public class OfficeProcessTest {
+
+    public void foundExistingProcessAndKill_Linux() throws Exception {
+        if (!PlatformUtils.isLinux()) {
+            throw new SkipException("LinuxProcessManager can only be tested on Linux");
+        }
+        this.foundExistingProcessAndKill(new UnixProcessManager());
+    }
+    
+    public void foundExistingProcessAndKill_MacOS() throws Exception {
+        if (!PlatformUtils.isMac()) {
+            throw new SkipException("MacProcessManager can only be tested on MacOS");
+        }
+        this.foundExistingProcessAndKill(new MacProcessManager());
+    }
+    
+    public void foundExistingProcessAndKill_Windows() throws Exception {
+        if (!PlatformUtils.isWindows()) {
+            throw new SkipException("WindowsProcessManager can only be tested on Windows");
+        }
+        this.foundExistingProcessAndKill(new WindowsProcessManager());
+    }
+
+    private void foundExistingProcessAndKill(ProcessManager processManager) throws Exception {
+        UnoUrl unoUrl = UnoUrl.socket(2022);
+        String processRegex = "soffice.*" + Pattern.quote(unoUrl.getAcceptString());
+        
+        ManagedOfficeProcessSettings settings = new ManagedOfficeProcessSettings(unoUrl);
+        settings.setProcessManager(processManager);
+        settings.setKillExistingProcess(true);
+        ManagedOfficeProcess proc = new ManagedOfficeProcess(settings);
+        try {
+            proc.startAndWait();
+
+            String procPid = settings.getProcessManager().findPid(processRegex);
+            System.out.println(procPid);
+            assertNotNull(procPid);
+
+            ManagedOfficeProcess proc2 = new ManagedOfficeProcess(settings);
+            try {
+                proc2.startAndWait();
+                String proc2Pid = settings.getProcessManager().findPid(processRegex);
+                System.out.println(proc2Pid);
+                assertNotNull(proc2Pid);
+                assertFalse(((OfficeProcess) ReflectionUtils.getPrivateField(proc, "process")).isRunning());
+            } finally {
+                proc2.stopAndWait();
+            }
+
+        } finally {
+            proc.stopAndWait();
+        }
+    }
+    
+    public void foundExistingProcessAndError_Linux() throws Exception {
+        if (!PlatformUtils.isLinux()) {
+            throw new SkipException("LinuxProcessManager can only be tested on Linux");
+        }
+        this.foundExistingProcessAndError(new UnixProcessManager());
+    }
+    
+    public void foundExistingProcessAndError_MacOS() throws Exception {
+        if (!PlatformUtils.isMac()) {
+            throw new SkipException("MacProcessManager can only be tested on MacOS");
+        }
+        this.foundExistingProcessAndError(new MacProcessManager());
+    }
+    
+    public void foundExistingProcessAndError_Windows() throws Exception {
+        if (!PlatformUtils.isWindows()) {
+            throw new SkipException("WindowsProcessManager can only be tested on Windows");
+        }
+        this.foundExistingProcessAndError(new WindowsProcessManager());
+    }
+    
+    private void foundExistingProcessAndError(ProcessManager processManager) throws Exception {
+        UnoUrl unoUrl = UnoUrl.socket(2022);
+        String processRegex = "soffice.*" + Pattern.quote(unoUrl.getAcceptString());
+        ManagedOfficeProcessSettings settings = new ManagedOfficeProcessSettings(unoUrl);
+        settings.setProcessManager(processManager);
+        settings.setKillExistingProcess(false);
+        ManagedOfficeProcess proc = new ManagedOfficeProcess(settings);
+        try {
+            proc.startAndWait();
+
+            String procPid = settings.getProcessManager().findPid(processRegex);
+            System.out.println(procPid);
+            assertNotNull(procPid);
+
+            ManagedOfficeProcess proc2 = new ManagedOfficeProcess(settings);
+            try {
+                proc2.startAndWait();
+                fail();
+            } catch (OfficeException e) {
+                // ok
+            } finally {
+                try {
+                    proc2.stopAndWait();
+                } catch (Exception e) {}
+            }
+
+        } finally {
+            proc.stopAndWait();
+        }
+    }
+}


### PR DESCRIPTION
Hi,

I just integrated works from arielnetworks/jodconverter into your implementation.

Basically, it helps ensure any existing process managed by JOD will be killed before restarting a new one.

Best regards.
